### PR TITLE
Add support for RedHat based OS's.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,11 @@ class reprepro::params {
       $user_name    = 'reprepro'
       $group_name   = 'reprepro'
     }
+    'RedHat': {
+      $package_name = 'reprepro'
+      $user_name    = 'reprepro'
+      $group_name   = 'reprepro'
+    }
     default: {
       fail("Unsupported osfamily: ${::osfamily}")
     }


### PR DESCRIPTION
This PR basically adds a very simple change to make this work on a RedHat based system.  EPEL provides reprepro so technically this does mean the module would need EPEL to be configured.  I did not explicitly reflect that anywhere.