### PR TITLE
require reprepro class in distribution

### DIFF
--- a/manifests/distribution.pp
+++ b/manifests/distribution.pp
@@ -72,6 +72,7 @@ define reprepro::distribution (
   $log                    = '',
 ) {
 
+  require reprepro
   include reprepro::params
 
   $notify = $ensure ? {


### PR DESCRIPTION
we need to require the class to get the username for running exec.
This also fixes one spec test !