### PR TITLE
Concat ensure

### DIFF
--- a/manifests/distribution.pp
+++ b/manifests/distribution.pp
@@ -80,7 +80,6 @@ define reprepro::distribution (
   }
 
   concat::fragment { "distribution-${name}":
-    ensure  => $ensure,
     target  => "${basedir}/${repository}/conf/distributions",
     content => template('reprepro/distribution.erb'),
     notify  => $notify,

--- a/manifests/pull.pp
+++ b/manifests/pull.pp
@@ -71,7 +71,6 @@ define reprepro::pull (
   }
 
   concat::fragment {"pulls-${name}":
-    ensure  => $ensure,
     target  => "${basedir}/${repository}/conf/pulls",
     content => template('reprepro/pull.erb'),
   }

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -143,7 +143,6 @@ define reprepro::repository (
   }
 
   concat::fragment { "00-distributions-${name}":
-    ensure  => $ensure,
     content => "# Puppet managed\n",
     target  => "${basedir}/${name}/conf/distributions",
   }
@@ -157,7 +156,6 @@ define reprepro::repository (
   }
 
   concat::fragment { "00-update-${name}":
-    ensure  => $ensure,
     content => "# Puppet managed\n",
     target  => "${basedir}/${name}/conf/updates",
   }
@@ -171,7 +169,6 @@ define reprepro::repository (
   }
 
   concat::fragment { "00-pulls-${name}":
-    ensure  => $ensure,
     content => "# Puppet managed\n",
     target  => "${basedir}/${name}/conf/pulls",
   }

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -87,7 +87,6 @@ define reprepro::update (
   }
 
   concat::fragment {"update-${name}":
-    ensure  => $ensure,
     content => template('reprepro/update.erb'),
     target  => "${basedir}/${repository}/conf/updates",
   }


### PR DESCRIPTION
The ensure parameter is not supported in recent `concat` module anymore.